### PR TITLE
Updating to go 1.23.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/denisenkom/go-mssqldb
 
-go 1.11
+go 1.23.7
 
 require (
-	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe
-	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
+	golang.org/x/crypto v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
+github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/mssql.go
+++ b/mssql.go
@@ -11,26 +11,44 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/denisenkom/go-mssqldb/internal/querytext"
 )
 
+var registeringMutex sync.RWMutex
+
 // ReturnStatus may be used to return the return value from a proc.
 //
-//   var rs mssql.ReturnStatus
-//   _, err := db.Exec("theproc", &rs)
-//   log.Printf("return status = %d", rs)
+//	var rs mssql.ReturnStatus
+//	_, err := db.Exec("theproc", &rs)
+//	log.Printf("return status = %d", rs)
 type ReturnStatus int32
 
 var driverInstance = &Driver{processQueryText: true}
 var driverInstanceNoProcess = &Driver{processQueryText: false}
 
 func init() {
-	sql.Register("mssql", driverInstance)
-	sql.Register("sqlserver", driverInstanceNoProcess)
+	registeringMutex.Lock()
+	defer registeringMutex.Unlock()
+
+	const (
+		mssqlStr     = "mssql"
+		sqlserverStr = "sqlserver"
+	)
+	registeredDrivers := sql.Drivers()
+	if !slices.Contains(registeredDrivers, mssqlStr) {
+		sql.Register(mssqlStr, driverInstance)
+	}
+
+	if !slices.Contains(registeredDrivers, sqlserverStr) {
+		sql.Register(sqlserverStr, driverInstance)
+	}
+
 	createDialer = func(p *connectParams) Dialer {
 		return netDialer{&net.Dialer{KeepAlive: p.keepAlive}}
 	}
@@ -771,12 +789,13 @@ func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
 // not a variable length type ok should return false.
 // If length is not limited other than system limits, it should return math.MaxInt64.
 // The following are examples of returned values for various types:
-//   TEXT          (math.MaxInt64, true)
-//   varchar(10)   (10, true)
-//   nvarchar(10)  (10, true)
-//   decimal       (0, false)
-//   int           (0, false)
-//   bytea(30)     (30, true)
+//
+//	TEXT          (math.MaxInt64, true)
+//	varchar(10)   (10, true)
+//	nvarchar(10)  (10, true)
+//	decimal       (0, false)
+//	int           (0, false)
+//	bytea(30)     (30, true)
 func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 	return makeGoLangTypeLength(r.cols[index].ti)
 }
@@ -784,9 +803,10 @@ func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 // It should return
 // the precision and scale for decimal types. If not applicable, ok should be false.
 // The following are examples of returned values for various types:
-//   decimal(38, 4)    (38, 4, true)
-//   int               (0, 0, false)
-//   decimal           (math.MaxInt64, math.MaxInt64, true)
+//
+//	decimal(38, 4)    (38, 4, true)
+//	int               (0, 0, false)
+//	decimal           (math.MaxInt64, math.MaxInt64, true)
 func (r *Rows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 	return makeGoLangTypePrecisionScale(r.cols[index].ti)
 }


### PR DESCRIPTION
Panic happens when more than one go-routine call the `sql.Register` function. This PR tries to fix that issue and also update the go version. 